### PR TITLE
Feature: 채팅 페이지에 state 관리를 적용

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,5 +54,7 @@ module.exports = {
         js: 'never', jsx: 'never', ts: 'never', tsx: 'never',
       },
     ],
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error'],
   },
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "next": "13.4.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "zustand": "^4.3.9"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/components/chat/Footer.tsx
+++ b/src/components/chat/Footer.tsx
@@ -1,26 +1,44 @@
 // 채팅 입력하는 부분이 생길 예정
 import { useState, ChangeEvent, FormEvent } from 'react';
-import type { FC } from 'react';
 import { css } from '@emotion/react';
 import Image from 'next/image';
 import color from '@/styles/color';
+import useChatStore from '@/store/chat';
 
-interface FooterProps {
-  // TODO: 혜성 엑스퍼트의 HELP. message 변수를 잘 쓰고 있는데 ESLint가 억까하는 중입니다.
-  // eslint-disable-next-line no-unused-vars
-  addChatContents: (message: string, timestamp: number) => void;
-}
-
-const Footer: FC<FooterProps> = ({ addChatContents }) => {
+const Footer = () => {
+  const {
+    addChatContents, idCounter, increaseIdCounter,
+  } = useChatStore();
   const [message, setMessage] = useState('');
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-
+    let result = null;
     if (message) {
-      addChatContents(message, Date.now());
+      const timestamp = Date.now();
+      addChatContents({
+        id: idCounter, speaker: 'me', content: message, timestamp,
+      });
+      increaseIdCounter();
       setMessage('');
+
+      // TODO: AI의 대답으로 수정될 부분 (API 호출했다고 가정)
+      result = await callLeeyjAPI(timestamp);
     }
+    return result;
+  };
+
+  const callLeeyjAPI = async (timestamp: number) => {
+    const response = await fetch('/api/hello');
+    const jsonData = await response.json();
+
+    // 함수의 input값인 message, timestamp를 아직 안쓰고 있어서 콘솔로그 찍어놓음
+    console.log(message, timestamp);
+
+    addChatContents({
+      id: idCounter + 1, speaker: '이영준', content: jsonData.say, timestamp: Date.now(),
+    });
+    increaseIdCounter();
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/chat/Main.tsx
+++ b/src/components/chat/Main.tsx
@@ -1,14 +1,12 @@
 // 주요 채팅 내용이 들어올 예정
-import { useRef, type FC, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import { css } from '@emotion/react';
+import useChatStore from '@/store/chat';
 import MySpeak from './MySpeak';
 import CharacterSpeak from './CharacterSpeak';
 
-interface MainProps {
-  chatContents: {id: number, speaker: string, content: string, timestamp: number}[];
-}
-
-const Main: FC<MainProps> = ({ chatContents }) => {
+const Main = () => {
+  const { chatContents } = useChatStore();
   const messageEndRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {

--- a/src/pages/chat/leeyj.tsx
+++ b/src/pages/chat/leeyj.tsx
@@ -5,47 +5,20 @@ import useChatStore from '@/store/chat';
 import { css } from '@emotion/react';
 
 const Leeyj = () => {
-  const {
-    chatContents, addChatContents, idCounter, increaseIdCounter,
-  } = useChatStore();
-
-  const addChatContent = async (message: string, timestamp: number) => {
-    // TODO: AI 대답 API나 소켓 통신이 가능하게 되면 다시 돌려놓을 코드
-
-    addChatContents({
-      id: idCounter, speaker: 'me', content: message, timestamp,
-    });
-    increaseIdCounter();
-
-    // TODO: AI의 대답으로 수정될 부분 (API 호출했다고 가정)
-    return callLeeyjAPI(message, timestamp);
-  };
-
-  const callLeeyjAPI = async (message : string, timestamp: number) => {
-    const response = await fetch('/api/hello');
-    const jsonData = await response.json();
-
-    // 함수의 input값인 message, timestamp를 아직 안쓰고 있어서 콘솔로그 찍어놓음
-    console.log(message, timestamp);
-
-    addChatContents({
-      id: idCounter + 1, speaker: '이영준', content: jsonData.say, timestamp: Date.now(),
-    });
-    increaseIdCounter();
-  };
+  const { chatContents } = useChatStore();
 
   return (
-    <section css={pageCss}>
+    <section css={pageCSS}>
       <Header />
       <Main chatContents={chatContents} />
-      <Footer addChatContents={addChatContent} />
+      <Footer />
     </section>
   );
 };
 
 export default Leeyj;
 
-const pageCss = css`
+const pageCSS = css`
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/pages/chat/leeyj.tsx
+++ b/src/pages/chat/leeyj.tsx
@@ -1,23 +1,21 @@
 import Footer from '@/components/chat/Footer';
 import Header from '@/components/chat/Header';
 import Main from '@/components/chat/Main';
+import useChatStore from '@/store/chat';
 import { css } from '@emotion/react';
-import { useState } from 'react';
-
-interface chatContentsState {
-  id: number, speaker: string, content: string, timestamp: number
-}
 
 const Leeyj = () => {
-  const [chatContents, setChatContents] = useState<chatContentsState[]>([]);
-  const [idCounter, setIdCounter] = useState<number>(0);
+  const {
+    chatContents, addChatContents, idCounter, increaseIdCounter,
+  } = useChatStore();
 
   const addChatContent = async (message: string, timestamp: number) => {
     // TODO: AI 대답 API나 소켓 통신이 가능하게 되면 다시 돌려놓을 코드
-    setChatContents([...chatContents, {
+
+    addChatContents({
       id: idCounter, speaker: 'me', content: message, timestamp,
-    }]);
-    // setIdCounter(idCounter + 1);
+    });
+    increaseIdCounter();
 
     // TODO: AI의 대답으로 수정될 부분 (API 호출했다고 가정)
     return callLeeyjAPI(message, timestamp);
@@ -26,13 +24,14 @@ const Leeyj = () => {
   const callLeeyjAPI = async (message : string, timestamp: number) => {
     const response = await fetch('/api/hello');
     const jsonData = await response.json();
-    setChatContents([...chatContents, {
-      id: idCounter, speaker: 'me', content: message, timestamp,
-    },
-    {
+
+    // 함수의 input값인 message, timestamp를 아직 안쓰고 있어서 콘솔로그 찍어놓음
+    console.log(message, timestamp);
+
+    addChatContents({
       id: idCounter + 1, speaker: '이영준', content: jsonData.say, timestamp: Date.now(),
-    }]);
-    setIdCounter(idCounter + 2);
+    });
+    increaseIdCounter();
   };
 
   return (

--- a/src/pages/chat/leeyj.tsx
+++ b/src/pages/chat/leeyj.tsx
@@ -1,20 +1,15 @@
 import Footer from '@/components/chat/Footer';
 import Header from '@/components/chat/Header';
 import Main from '@/components/chat/Main';
-import useChatStore from '@/store/chat';
 import { css } from '@emotion/react';
 
-const Leeyj = () => {
-  const { chatContents } = useChatStore();
-
-  return (
-    <section css={pageCSS}>
-      <Header />
-      <Main chatContents={chatContents} />
-      <Footer />
-    </section>
-  );
-};
+const Leeyj = () => (
+  <section css={pageCSS}>
+    <Header />
+    <Main />
+    <Footer />
+  </section>
+);
 
 export default Leeyj;
 

--- a/src/store/chat.ts
+++ b/src/store/chat.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+interface ChatContentsState {
+  id: number, speaker: string, content: string, timestamp: number
+}
+
+interface ChatState {
+  chatContents: ChatContentsState[],
+  addChatContents: (newChat: ChatContentsState) => void;
+  idCounter: number,
+  increaseIdCounter: () => void;
+}
+
+const useChatStore = create<ChatState>((set) => ({
+  chatContents: [],
+  addChatContents: (newChat) => set(
+    (state) => ({ chatContents: [...state.chatContents, newChat] }),
+  ),
+  idCounter: 0,
+  increaseIdCounter: () => set((state) => ({ idCounter: state.idCounter + 1 })),
+}));
+
+export default useChatStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4756,6 +4756,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 v8-to-istanbul@^9.0.1:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz#1b83ed4e397f58c85c266a570fc2558b5feb9265"
@@ -4950,3 +4955,10 @@ zod@3.21.4:
   version "3.21.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
   integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
+
+zustand@^4.3.9:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.9.tgz#a7d4332bbd75dfd25c6848180b3df1407217f2ad"
+  integrity sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
- props의 늪을 지나 store의 세계로 갑니다.
- chat page(leeyj 이영준)에 채팅 내용을 받고 올려주고 내려주는 props를 위해 긴 코드를 작성해야만 했음.
- 간단한 리팩토링을 통해서 page 부분의 큰 책임을 해소함. 
- state 관리를 위해 `zustand`를 도입.