### PR TITLE
🐝 Fix: useState로 인해 화면 랜더링 막힘

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -15,11 +15,9 @@ interface CharacterState {
 const MessageInput : FC<CharacterState> = ({ characterId, characterName }) => {
   const { addChatContents, loadedChat } = useChatStore();
   const [message, setMessage] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [loading] = useState(true);
 
   // TODO: input이 많아서 loading이 쌓인 경우 false로 풀어줘야함.
-  console.log(loading);
-  setLoading(false);
   console.log(loading);
 
   const handleSubmit = async (e: FormEvent) => {


### PR DESCRIPTION
- 다음 브랜치에서 작업하기 위해서 남겨놓은 SetLoading때문에 화면이 랜더링안되는 것을 확인함