### PR TITLE
Feature: 채팅 timestamp 순으로 정렬

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -37,8 +37,8 @@ const MessageInput : FC<CharacterState> = ({ characterId, characterName }) => {
   };
 
   const callLeeyjAPI = async (timestamp: number) => {
-    const index = addChatContents({
-      speaker: characterName, content: 'loading', timestamp: new Date('2100-12-31 00:00:00').getTime(), loading: true,
+    const loadingTimestamp = addChatContents({
+      speaker: characterName, content: 'loading', timestamp: Date.now() + new Date('2100-12-31 00:00:00').getTime(), loading: true,
     });
     const response = await fetch(`/api/${characterId}`);
     const jsonData = await response.json();
@@ -46,7 +46,7 @@ const MessageInput : FC<CharacterState> = ({ characterId, characterName }) => {
     // 함수의 input값인 message, timestamp를 아직 안쓰고 있어서 콘솔로그 찍어놓음
     console.log(message, timestamp);
 
-    loadedChat(index, jsonData.say, Date.now());
+    loadedChat(loadingTimestamp, jsonData.say, Date.now());
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -38,7 +38,7 @@ const MessageInput : FC<CharacterState> = ({ characterId, characterName }) => {
 
   const callLeeyjAPI = async (timestamp: number) => {
     const index = addChatContents({
-      speaker: characterName, content: 'loading', timestamp: 0, loading: true,
+      speaker: characterName, content: 'loading', timestamp: new Date('2100-12-31 00:00:00').getTime(), loading: true,
     });
     const response = await fetch(`/api/${characterId}`);
     const jsonData = await response.json();

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -15,7 +15,7 @@ interface CharacterState {
 const MessageInput : FC<CharacterState> = ({ characterId, characterName }) => {
   const { addChatContents, loadedChat } = useChatStore();
   const [message, setMessage] = useState('');
-  const [loading] = useState(true);
+  const [loading] = useState(false);
 
   // TODO: input이 많아서 loading이 쌓인 경우 false로 풀어줘야함.
   console.log(loading);

--- a/src/pages/api/leeyj.ts
+++ b/src/pages/api/leeyj.ts
@@ -11,7 +11,7 @@ export default function handler(
 ) {
   setTimeout(() => {
     res.status(200).json({ say: jySay() });
-  }, Math.random() * 8000);
+  }, Math.random() * 5000);
 }
 
 const jySay = () => {

--- a/src/store/chat.ts
+++ b/src/store/chat.ts
@@ -24,12 +24,12 @@ const useChatStore = create<ChatState>((set, get) => ({
       }),
     );
     get().sortingChat();
-    return get().chatContents.length - 1;
+    return newChat.timestamp;
   },
-  loadedChat: (loadedIndex, message, timestamp) => set(
+  loadedChat: (loadingTimestamp, message, timestamp) => set(
     (state) => ({
-      chatContents: state.chatContents.map((chatContent, index) => {
-        if (index === loadedIndex) {
+      chatContents: state.chatContents.map((chatContent) => {
+        if (chatContent.timestamp === loadingTimestamp) {
           return {
             ...chatContent, loading: false, content: message, timestamp,
           };

--- a/src/store/chat.ts
+++ b/src/store/chat.ts
@@ -12,6 +12,7 @@ interface ChatState {
   chatContents: ChatContentsState[],
   addChatContents: (newChat: NewChatContentState) => number;
   loadedChat: (loadedIndex: number, message: string, timestamp: number) => void;
+  sortingChat: () => void;
 }
 
 const useChatStore = create<ChatState>((set, get) => ({
@@ -22,6 +23,7 @@ const useChatStore = create<ChatState>((set, get) => ({
         chatContents: [...state.chatContents, { ...newChat, id: state.chatContents.length + 1 }],
       }),
     );
+    get().sortingChat();
     return get().chatContents.length - 1;
   },
   loadedChat: (loadedIndex, message, timestamp) => set(
@@ -32,8 +34,16 @@ const useChatStore = create<ChatState>((set, get) => ({
             ...chatContent, loading: false, content: message, timestamp,
           };
         }
+        get().sortingChat();
         return chatContent;
       }),
+    }),
+  ),
+  sortingChat: () => set(
+    (state) => ({
+      chatContents: state.chatContents.sort(
+        (a, b) => a.timestamp - b.timestamp,
+      ),
     }),
   ),
 }));


### PR DESCRIPTION
- timestamp 순으로 정렬하게 되면서 응답이 오기 전에 채팅을 날렸을 때 채팅이 들어간 순서대로 배열할 수 있음.
- 기존에 index로 loaded된 채팅을 확인하는 방식은 현재에도 sort를 거치면서 문제가 생겼고 이후 채팅내역 페이지네이션 기능이 추가되었을 때 문제가 될 수 있기에 timestamp를 통해 확인하는 방식으로 변경함.