### PR TITLE
Fix: 채팅에서 사용되는 이미지가 CSS 상에서 짜부되는 상황

### DIFF
--- a/src/components/chat/Header.tsx
+++ b/src/components/chat/Header.tsx
@@ -55,6 +55,7 @@ const headerCSS = css`
   top: 0;
   z-index: 100; // 채팅보다 위에 존재해야하기 때문에 필요함
   width: 100%;
+  max-width: 400px;
   padding: 0.25rem;
   display: flex;
   flex-direction: row;

--- a/src/components/chat/Main.tsx
+++ b/src/components/chat/Main.tsx
@@ -77,6 +77,7 @@ export default Main;
 
 const mainCSS = css`
   padding: 0.25rem;
+  max-width: 400px;
   width: 100%;
   height: 100%;
   overflow: auto;

--- a/src/components/chat/characterHeader/CharacterInfo.tsx
+++ b/src/components/chat/characterHeader/CharacterInfo.tsx
@@ -71,4 +71,8 @@ const characterNameCSS = css`
 const characterBackgroundCSS = css`
   font-size: 0.75rem;
   color: ${color.greenGray};
+  overflow: hidden;  // 넘치면 영역을 감추기
+  text-overflow: ellipsis; // ... 으로 마무리
+  white-space: nowrap; // 아래줄로 내려가는 것을 막기
+  max-width: 11rem;
 `;

--- a/src/components/chat/messageBox/CharacterSpeak.tsx
+++ b/src/components/chat/messageBox/CharacterSpeak.tsx
@@ -52,6 +52,7 @@ const characterNameCSS = css`
 const imageWrapperCSS = css`
   margin: 0.25rem;
   width: 2.5rem;
+  min-width: 2.5rem;
   height: 2.5rem;
   position: relative;
 `;

--- a/src/pages/api/userStatus/[character_id].tsx
+++ b/src/pages/api/userStatus/[character_id].tsx
@@ -17,9 +17,6 @@ export default function handler(
   req: NextApiRequestWithId,
   res: NextApiResponse<Data>,
 ) {
-  const characterId = req.query.character_id;
-
-  console.log(characterId);
   res.status(200).json({
     friendShipExp: Math.random() * 200,
     maxFriendShipExp: 200,


### PR DESCRIPTION
- 기존 px 기반일때 많은 텍스트가 들어가면 짜뿌되지 않도록 했었는데, rem 기반이 되면서 강하게 막아뒀던게 풀려버림