### PR TITLE
Fix: 채팅 입력시 화면 스크롤이 위로 튀는 상황 제어

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -22,18 +22,16 @@ const MessageInput : FC<CharacterState> = () => {
   const { sendMessage } = useSocketStore();
 
   useEffect(() => {
-    const handleFocus = () => {
+    const handleResize = () => {
       if (inputRef.current) {
         inputRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
       }
     };
-    if (inputRef.current) {
-      inputRef.current.addEventListener('focus', handleFocus);
-    }
+
+    window.addEventListener('resize', handleResize);
+
     return () => {
-      if (inputRef.current) {
-        inputRef.current.removeEventListener('focus', handleFocus);
-      }
+      window.removeEventListener('resize', handleResize);
     };
   }, []);
 

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -24,7 +24,7 @@ const MessageInput : FC<CharacterState> = () => {
   useEffect(() => {
     const handleFocus = () => {
       if (inputRef.current) {
-        window.scrollTo(0, inputRef.current.offsetTop - 100); // 100은 여백 (해보고 바꿔야함)
+        inputRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
       }
     };
     if (inputRef.current) {


### PR DESCRIPTION
기존에 모바일 환경에서 가상 키패드가 나오면 input 부분이 가려지는 상황을 막기 위해서 스크롤링을 넣어뒀었는데
그 부분에서 스크롤이 거의 맨 위로 올라가게 만들어놔서 생긴 문제이고 해결하기 위해서 화면 resize시 다시 재배치하는 것으로 조치함