### PR TITLE
Feature: 현재 나와있는 최근 채팅, History 가져오기 API 연결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   env: {
     SOCKET_URL: process.env.SOCKET_URL,
+    SERVER_URL: process.env.SERVER_URL,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test:e2e": "playwright test",
     "test:e2e-ui": "playwright test --ui",
     "test:e2e-report": "playwright show-report"
-
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
@@ -27,6 +26,7 @@
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "@types/sockjs-client": "^1.5.1",
+    "axios": "^1.4.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-next": "13.4.8",
     "next": "13.4.8",

--- a/src/components/chat/Main.tsx
+++ b/src/components/chat/Main.tsx
@@ -4,6 +4,7 @@ import {
 } from 'react';
 import { css } from '@emotion/react';
 import useChatStore from '@/store/chat';
+import getHistory from '@/utils/services/chats';
 import MySpeak from './messageBox/MySpeak';
 import CharacterSpeak from './messageBox/CharacterSpeak';
 import Loading from '../common/dialog/Loading';
@@ -14,19 +15,6 @@ interface MainProps {
   imageUrl: string
 }
 
-type BotChat = { bot: string, timestamp: number }
-type HumanChat = { human: string, timestamp: number }
-
-// TODO: util같은 폴더에 따로 모아둬야할 것 같은 기능.
-const historyToContents = (histories: (
-  BotChat|HumanChat)[], characterName: string) => histories.map((history, index) => ({
-  id: index,
-  speaker: 'bot' in history ? characterName : 'me',
-  content: 'bot' in history ? history.bot : history.human,
-  timestamp: history.timestamp,
-  loading: false,
-}));
-
 const Main:FC<MainProps> = ({ characterId, characterName, imageUrl }) => {
   const { chatContents, clearChatContents, initChatContents } = useChatStore();
   const messageEndRef = useRef<HTMLDivElement | null>(null);
@@ -36,13 +24,7 @@ const Main:FC<MainProps> = ({ characterId, characterName, imageUrl }) => {
     // TODO: Loading으로 채팅을 못치게 막아야할 것 같음
     clearChatContents();
     setLoadingHistory(true);
-    fetch(`/api/chat/${characterId}`)
-      .then((res) => res.json())
-      .then((data) => {
-        setLoadingHistory(false);
-        initChatContents(historyToContents(data.history, characterName));
-      });
-    // setLoadingHistory(false);
+    getHistory(setLoadingHistory, characterId, characterName, initChatContents);
   }, [characterId, characterName, clearChatContents, initChatContents]);
   useEffect(() => {
     messageEndRef.current?.scrollIntoView({ behavior: 'smooth' });

--- a/src/components/friends/ChatLogs.tsx
+++ b/src/components/friends/ChatLogs.tsx
@@ -1,31 +1,58 @@
 import { css } from '@emotion/react';
 import TimeStamp from '@/components/common/timeStamp/TimeStamp';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 import FriendWrapper from './friend/FriendWrapper';
 import FriendInfo from './friend/FriendInfo';
 import ChatBadge from './friend/ChatBadge';
 
-const ChatLogs = () => (
-  <section css={chatLogsWrapperCSS}>
-    {chatLogDataSet.map((data, index) => (
-      // TODO: 여러 캐릭터가 있을 때 스크롤이 가능한지 확인하기 위함
-      <FriendWrapper
-        // eslint-disable-next-line react/no-array-index-key
-        key={index}
-        linkUrl={`/chats/${data.characterId}`}
-      >
-        <FriendInfo
-          characterName={data.characterName}
-          message={data.message}
-          imageUrl={data.imageUrl}
-        />
-        <div css={subInfoWrapperCSS}>
-          <TimeStamp timestamp={data.timestamp} />
-          <ChatBadge unreadCount={data.unreadCount} />
-        </div>
-      </FriendWrapper>
-    ))}
-  </section>
-);
+interface RecentData {
+  content: string,
+  characterName: string,
+  createdAt: number,
+}
+
+const ChatLogs = () => {
+  // TODO: 데이터셋을 한 번에 API로 받아오면 더 편하게 작업할 수 있을 것 같음
+  const [chatLogDataSet, setchatLogDataSet] = useState(chatLogDataSample);
+
+  const callRecentAPI = async (index: number, characterId: string) => {
+    const recentData = await axios.get<RecentData>(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}?recent=true`);
+    chatLogDataSet[index].characterName = recentData.data.characterName;
+    chatLogDataSet[index].message = recentData.data.content;
+    chatLogDataSet[index].timestamp = recentData.data.createdAt;
+    setchatLogDataSet([...chatLogDataSet]);
+  };
+
+  useEffect(() => {
+    for (let i = 0; i < chatLogDataSet.length; i += 1) {
+      callRecentAPI(i, i.toString());
+    }
+  }, []);
+
+  return (
+    <section css={chatLogsWrapperCSS}>
+      {chatLogDataSet.map((data, index) => (
+        // TODO: 여러 캐릭터가 있을 때 스크롤이 가능한지 확인하기 위함
+        <FriendWrapper
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          linkUrl={`/chats/${data.characterId}`}
+        >
+          <FriendInfo
+            characterName={data.characterName}
+            message={data.message}
+            imageUrl={data.imageUrl}
+          />
+          <div css={subInfoWrapperCSS}>
+            <TimeStamp timestamp={data.timestamp} />
+            <ChatBadge unreadCount={data.unreadCount} />
+          </div>
+        </FriendWrapper>
+      ))}
+    </section>
+  );
+};
 
 export default ChatLogs;
 
@@ -44,86 +71,19 @@ const subInfoWrapperCSS = css`
   margin-right: 0.625rem;
 `;
 
-// TODO: 이 부분은 API에서 떼와야하는 부분
-const chatLogDataSet = [
+const chatLogDataSample = [
   {
-    characterName: '이영준',
     characterId: '0',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '(자아도취에 빠진다)',
+    characterName: '이영준',
     imageUrl: '/leeyj.png',
+    message: '.',
     timestamp: 123123,
     unreadCount: 1,
   }, {
-    characterName: '김미소',
     characterId: '1',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '조만간 퇴사할 생각이에요.',
-    imageUrl: '/kimms.png',
-    timestamp: 123123,
-    unreadCount: 0,
-  }, {
-    characterName: '이영준',
-    characterId: '0',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '(자아도취에 빠진다))',
-    imageUrl: '/leeyj.png',
-    timestamp: 123123,
-    unreadCount: 3,
-  }, {
     characterName: '김미소',
-    characterId: '1',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '조만간 퇴사할 생각이에요.',
     imageUrl: '/kimms.png',
-    timestamp: 123123,
-    unreadCount: 0,
-  }, {
-    characterName: '이영준',
-    characterId: '0',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '(자아도취에 빠진다)',
-    imageUrl: '/leeyj.png',
-    timestamp: 123123,
-    unreadCount: 0,
-  }, {
-    characterName: '김미소',
-    characterId: '1',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '조만간 퇴사할 생각이에요.',
-    imageUrl: '/kimms.png',
-    timestamp: 123123,
-    unreadCount: 0,
-  }, {
-    characterName: '이영준',
-    characterId: '0',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '(자아도취에 빠진다)',
-    imageUrl: '/leeyj.png',
-    timestamp: 123123,
-    unreadCount: 0,
-  }, {
-    characterName: '김미소',
-    characterId: '1',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '조만간 퇴사할 생각이에요.',
-    imageUrl: '/kimms.png',
-    timestamp: 123123,
-    unreadCount: 0,
-  }, {
-    characterName: '이영준',
-    characterId: '0',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '(자아도취에 빠진다)',
-    imageUrl: '/leeyj.png',
-    timestamp: 123123,
-    unreadCount: 0,
-  }, {
-    characterName: '김미소',
-    characterId: '1',
-    hashTag: '#카카오페이지 #김비서가왜그럴까',
-    message: '조만간 퇴사할 생각이에요.',
-    imageUrl: '/kimms.png',
+    message: '.',
     timestamp: 123123,
     unreadCount: 0,
   },

--- a/src/components/friends/ChatLogs.tsx
+++ b/src/components/friends/ChatLogs.tsx
@@ -1,26 +1,21 @@
 import { css } from '@emotion/react';
 import TimeStamp from '@/components/common/timeStamp/TimeStamp';
 import { useEffect, useState } from 'react';
-import defaultInstance from '@/utils/axiosInstance/defaultInstance';
+import { recentChatAPI } from '@/utils/api/chats';
 import FriendWrapper from './friend/FriendWrapper';
 import FriendInfo from './friend/FriendInfo';
 import ChatBadge from './friend/ChatBadge';
-
-interface RecentData {
-  createdAt: number;
-  content: string;
-  characterName: string;
-}
 
 const ChatLogs = () => {
   // TODO: 데이터셋을 한 번에 API로 받아오면 더 편하게 작업할 수 있을 것 같음
   const [chatLogDataSet, setchatLogDataSet] = useState(chatLogDataSample);
 
   const callRecentAPI = async (index: number, characterId: string) => {
-    const recentData = await defaultInstance.get<RecentData>(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}?recent=true`);
-    chatLogDataSet[index].characterName = recentData.data.characterName;
-    chatLogDataSet[index].message = recentData.data.content;
-    chatLogDataSet[index].timestamp = recentData.data.createdAt;
+    const recentData = await recentChatAPI(characterId);
+
+    chatLogDataSet[index].characterName = recentData.characterName;
+    chatLogDataSet[index].message = recentData.content;
+    chatLogDataSet[index].timestamp = recentData.createdAt;
     setchatLogDataSet([...chatLogDataSet]);
   };
 

--- a/src/components/friends/ChatLogs.tsx
+++ b/src/components/friends/ChatLogs.tsx
@@ -1,15 +1,15 @@
 import { css } from '@emotion/react';
 import TimeStamp from '@/components/common/timeStamp/TimeStamp';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import defaultInstance from '@/utils/axiosInstance/defaultInstance';
 import FriendWrapper from './friend/FriendWrapper';
 import FriendInfo from './friend/FriendInfo';
 import ChatBadge from './friend/ChatBadge';
 
 interface RecentData {
-  content: string,
-  characterName: string,
-  createdAt: number,
+  createdAt: number;
+  content: string;
+  characterName: string;
 }
 
 const ChatLogs = () => {
@@ -17,7 +17,7 @@ const ChatLogs = () => {
   const [chatLogDataSet, setchatLogDataSet] = useState(chatLogDataSample);
 
   const callRecentAPI = async (index: number, characterId: string) => {
-    const recentData = await axios.get<RecentData>(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}?recent=true`);
+    const recentData = await defaultInstance.get<RecentData>(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}?recent=true`);
     chatLogDataSet[index].characterName = recentData.data.characterName;
     chatLogDataSet[index].message = recentData.data.content;
     chatLogDataSet[index].timestamp = recentData.data.createdAt;

--- a/src/utils/api/chats.ts
+++ b/src/utils/api/chats.ts
@@ -1,15 +1,11 @@
 import defaultInstance from '@/utils/axiosInstance/defaultInstance';
 
-interface RecentData {
-  createdAt: number;
-  content: string;
-  characterName: string;
-}
-
 export const recentChatAPI = async (characterId: string) => {
-  const result = await defaultInstance.get<RecentData>(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}?recent=true`);
+  const result = await defaultInstance.get(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}?recent=true`);
   return result.data;
 };
 
-// TODO: 다른 API 만들기
-export const otherAPI = () => console.log(123);
+export const chatHistoryAPI = async (characterId: string) => {
+  const result = await defaultInstance.get(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}/history`);
+  return result.data;
+};

--- a/src/utils/api/chats.ts
+++ b/src/utils/api/chats.ts
@@ -1,0 +1,15 @@
+import defaultInstance from '@/utils/axiosInstance/defaultInstance';
+
+interface RecentData {
+  createdAt: number;
+  content: string;
+  characterName: string;
+}
+
+export const recentChatAPI = async (characterId: string) => {
+  const result = await defaultInstance.get<RecentData>(`${process.env.SERVER_URL || 'http://localhost:8080'}/chat/${characterId}?recent=true`);
+  return result.data;
+};
+
+// TODO: 다른 API 만들기
+export const otherAPI = () => console.log(123);

--- a/src/utils/axiosInstance/defaultInstance.ts
+++ b/src/utils/axiosInstance/defaultInstance.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const defaultInstance = axios.create({
+  baseURL: process.env.SERVER_URL || 'http://localhost:8080/',
+});
+
+export default defaultInstance;

--- a/src/utils/services/chats.ts
+++ b/src/utils/services/chats.ts
@@ -1,0 +1,32 @@
+import { chatHistoryAPI } from '../api/chats';
+
+interface ChatContentsState {
+  id: number, speaker: string, content: string, timestamp: number, loading: boolean,
+}
+
+interface resultData {
+  id: string, content: string, createdAt: number, messageTo: string;
+}
+
+type GetHistory = (
+  setLoading: (isLoading: boolean) => void,
+  characterId: string,
+  characterName: string,
+  initChatContents: (history:ChatContentsState[]) => void
+) => void
+
+const getHistory: GetHistory = async (setLoading, characterId, characterName, initChatContents) => {
+  setLoading(false);
+  const result = await chatHistoryAPI(characterId);
+  const history = result.map((data: resultData) => ({
+    id: data.id,
+    content: data.content,
+    timestamp: data.createdAt,
+    speaker: data.messageTo === characterId ? 'me' : characterName,
+  }));
+  initChatContents(history);
+};
+
+// TODO: history 관련 service 레이어 함수가 더 많아지면 아래 eslint 막은 것 풀기
+// eslint-disable-next-line import/no-anonymous-default-export
+export default getHistory;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,6 +1607,15 @@ axe-core@^4.6.2:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.1.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz"
@@ -2783,6 +2792,11 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -4630,6 +4644,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
## 현재 나와있는 최근 채팅, History 가져오기 API 연결

### PR을 한 이유 🎯

- Swagger에 올라온 API인 채팅 히스토리, 최근 채팅내역 가져오기 부분을 연결하는 작업입니다.

### 이슈 번호 📎

- cloesd #57 

### 변경사항 🛠

- `utils` 폴더를 만들고 하위에 API 호출에 필요한 레이어를 몇 개 만들었습니다.
  - `axiosInstance` 폴더에서 axios 인스턴스를 관리하는 레이어로 에러 핸들링, auth가 필요한 부분에 대한 분기에 사용할 예정입니다.
  - `api` 폴더에서 axios 인스턴스를 사용해 API를 호출합니다.
  - `service` 폴더에서는 객체의 형변환이나, 프론트에서 필요한 함수를 담습니다.

### 특이사항 📌

- 아쉽게도 채팅 읽었는 지 여부 (채팅 옆에 1이 떠있는지 안떠있는지를 알 수 없습니다! 백엔드 처리 이후에 가능할 것 같습니다.)
- `axios`에 대한 공부가 부족함을 느낍니다. 당장 내일 팀회의에 보여줘야하니 이대로 PR을 날리지만, base_url 처리가 잘 되지 않았습니다.
이후에 다른 API 작업을 하면서 리팩토링하면 될 것 같습니다.

### 테스트 결과 📝

**최근 채팅 내역**

<img width="300" alt="image" src="https://github.com/TeamATM/toonchat-client/assets/90738604/12b82ee2-a15d-4c20-ac13-c1848795dd7a">

**채팅 히스토리**

<img width="300" alt="image" src="https://github.com/TeamATM/toonchat-client/assets/90738604/073e466b-ecaf-447e-9b5e-f4645d8ff3b3">
