### PR TITLE
Feature: Next의 api에 CORS를 적용해보기

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -47,6 +47,7 @@ export const authOptions: NextAuthOptions = {
           password: credentials?.password || '',
           provider: 'credential',
         });
+
         if (data.nickname && data.accessToken) {
           const user = {
             accessToken: data.accessToken,
@@ -56,7 +57,6 @@ export const authOptions: NextAuthOptions = {
             email: credentials?.email,
             id: data.memberId,
           };
-
           return user;
         }
         return null;
@@ -75,7 +75,7 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async signIn({ user, account }) {
       if (account?.type === 'credentials') return true;
-      const response = await fetch(`${process.env.NEXT_PUBLIC_CLIENT_SERVER_URL || 'http://localhost:3000/api'}/users/social-login`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000/api'}/members/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -111,11 +111,14 @@ export const authOptions: NextAuthOptions = {
       return session;
     },
 
-    // async redirect({ url, baseUrl }) {
-    //   return url.startsWith(baseUrl)
-    //     ? Promise.resolve(url)
-    //     : Promise.resolve(baseUrl);
-    // },
+    async redirect({ url, baseUrl }) {
+      if (url.startsWith('/')) {
+        return `${baseUrl}${url}`;
+      } if (new URL(url).origin === baseUrl) {
+        return `${baseUrl}`;
+      }
+      return baseUrl;
+    },
   },
 };
 

--- a/src/pages/api/users/signup.ts
+++ b/src/pages/api/users/signup.ts
@@ -11,7 +11,10 @@ interface ExtendedNextApiRequest extends NextApiRequest {
 }
 
 export default async function handler(req: ExtendedNextApiRequest, res: NextApiResponse) {
-  const allowedOrigins = ['https://www.webtoonchat.com', 'https://webtoonchat.com', 'http://localhost:3000'];
+  const allowedOrigins = ['https://www.webtoonchat.com', 'https://webtoonchat.com'];
+  const isLocal = process.env.NEXT_PUBLIC_ENV === 'local';
+  if (isLocal) allowedOrigins.push('http://localhost:3000');
+
   const { origin } = req.headers;
 
   if (allowedOrigins.includes(origin || '')) {

--- a/src/pages/api/users/signup.ts
+++ b/src/pages/api/users/signup.ts
@@ -11,6 +11,16 @@ interface ExtendedNextApiRequest extends NextApiRequest {
 }
 
 export default async function handler(req: ExtendedNextApiRequest, res: NextApiResponse) {
+  const allowedOrigins = ['https://www.webtoonchat.com', 'https://webtoonchat.com', 'http://localhost:3000'];
+  const { origin } = req.headers;
+
+  if (allowedOrigins.includes(origin || '')) {
+    res.setHeader('Access-Control-Allow-Origin', origin || '');
+  }
+
+  res.setHeader('Access-Control-Allow-Methods', 'POST');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
   if (req.method !== 'POST') {
     return res.status(405).end();
   }


### PR DESCRIPTION
## Feature: Next의 api에 CORS를 적용해보기

### PR을 한 이유 🎯

- Next의 API에도 CORS를 적용해봤습니다.
- signup에 가장 먼저 필요해서 적용했습니다.

### 특이사항 📌

- 로컬 환경에서는 localhost:3000 에서 next api를 사용할 수 있도록 조치했습니다.
- next의 다른 자체 API에도 적용할 수 있을 것 같습니다.
