### PR TITLE
Feature: 게시글 작성 페이지 구현

### DIFF
--- a/src/components/community/postList/Post.tsx
+++ b/src/components/community/postList/Post.tsx
@@ -2,7 +2,6 @@ import { postDateParse } from '@/utils/services/date';
 import FriendWrapper from '@/components/friends/friend/FriendWrapper';
 import HeartIcon from '@/components/icons/HeartIcon';
 import CommentIcon from '@/components/icons/CommentIcon';
-import DivideLine from '@/components/common/divideLine/DivideLine';
 import color from '@/styles/color';
 import { css } from '@emotion/react';
 import { FC } from 'react';
@@ -35,7 +34,9 @@ const Post: FC<PostStates> = ({ characterId, post }) => (
         </li>
       </ul>
     </FriendWrapper>
-    <DivideLine />
+    <div css={lineContainerCSS}>
+      <div css={lineCSS} />
+    </div>
   </>
 );
 
@@ -69,4 +70,21 @@ const statusCSS = css`
   font-size: 0.625rem;
   font-weight: bold;
   color: ${color.black};
+`;
+
+const lineContainerCSS = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  color:  ${color.lightGray};
+  font-size: 0.875rem;
+`;
+
+const lineCSS = css`
+  display: block;
+  margin: 0.625rem;
+  height: 1px;
+  background: ${color.lightGray};
+  width: 100%;
 `;

--- a/src/pages/community/[character_id]/edit.tsx
+++ b/src/pages/community/[character_id]/edit.tsx
@@ -27,16 +27,20 @@ const Post = () => {
   return (
     <>
       <SEO title="Community - Post Editor" />
-      <PostHeader />
       <section css={pageCSS}>
-        <form onSubmit={handleSubmit} css={css`width: 100%;`}>
+        <PostHeader />
+        <form onSubmit={handleSubmit} css={formCSS}>
           <input type="text" placeholder="제목" css={inputTagCSS} value={title} onChange={(e) => setTitle(e.target.value)} required />
           <textarea
             value={content}
+            placeholder="내용을 입력해주세요."
             onChange={(e) => setContent(e.target.value)}
+            css={textareaCSS}
           />
-          <DivideLine />
-          <Button theme="green">글 작성</Button>
+          <div css={footerCSS}>
+            <DivideLine />
+            <Button theme="green">글 작성</Button>
+          </div>
         </form>
       </section>
     </>
@@ -49,6 +53,14 @@ const pageCSS = css`
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: space-between;
+`;
+
+const formCSS = css`
+  width: 100%;
+  height:100%;
+  display: flex;
+  flex-direction: column;
   padding: 0 3rem;
 `;
 
@@ -59,4 +71,18 @@ const inputTagCSS = css`
   outline: none;
   background: none;
   border: none;
+`;
+
+const textareaCSS = css`
+  width: 100%;
+  flex-grow: 1;
+  padding: 1rem;
+  resize: none;
+  border: none;
+  outline: none;
+  font-size: 0.75rem;
+`;
+
+const footerCSS = css`
+  padding-bottom: 1rem;
 `;

--- a/src/pages/community/[character_id]/edit.tsx
+++ b/src/pages/community/[character_id]/edit.tsx
@@ -4,24 +4,41 @@ import { FormEvent, useState } from 'react';
 import PostHeader from '@/components/community/PostHeader';
 import DivideLine from '@/components/common/divideLine/DivideLine';
 import Button from '@/components/common/button/Button';
-// import { useRouter } from 'next/router';
+import { createPost } from '@/utils/api/boards';
+import { useRouter } from 'next/router';
 
 const Post = () => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  // const router = useRouter();
+  const router = useRouter();
+  const { character_id: characterId } = router.query;
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (characterId && typeof characterId === 'string') {
+      if (title === '' || title.length > 30) {
+        alert('제목을 30자 이내로 작성해주세요! :)');
+        return;
+      }
 
-    // TODO: 게시글 유효성 검사를 해야함
+      if (content === '' || content.length > 3000) {
+        alert('내용은 3000자 이내로 작성해주세요! :)');
+        return;
+      }
 
-    alert(`${title}, ${content}`);
+      const result = await createPost(characterId, title, content);
 
-    // 게시글 작성 성공!
-    // router.push({
-    //   pathname: '/community',
-    // });
+      if (result.status === 201) {
+        router.push({
+          pathname: `/community/${characterId}`,
+        });
+        return;
+      }
+      alert('게시글 작성에 실패했습니다 :(');
+    }
+    router.push({
+      pathname: '/community',
+    });
   };
 
   return (

--- a/src/pages/community/[character_id]/edit.tsx
+++ b/src/pages/community/[character_id]/edit.tsx
@@ -1,29 +1,27 @@
 import { css } from '@emotion/react';
 import SEO from '@/components/common/head/SEO';
-import { ChangeEvent, FormEvent, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import PostHeader from '@/components/community/PostHeader';
 import DivideLine from '@/components/common/divideLine/DivideLine';
 import Button from '@/components/common/button/Button';
-import { useRouter } from 'next/router';
+// import { useRouter } from 'next/router';
 
 const Post = () => {
   const [title, setTitle] = useState('');
-  // const [content, setContent] = useState('');
-  const router = useRouter();
+  const [content, setContent] = useState('');
+  // const router = useRouter();
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     // TODO: 게시글 유효성 검사를 해야함
 
-    // 게시글 작성 성공!
-    router.push({
-      pathname: '/community',
-    });
-  };
+    alert(`${title}, ${content}`);
 
-  const titleHandler = (e: ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
+    // 게시글 작성 성공!
+    // router.push({
+    //   pathname: '/community',
+    // });
   };
 
   return (
@@ -32,7 +30,11 @@ const Post = () => {
       <PostHeader />
       <section css={pageCSS}>
         <form onSubmit={handleSubmit} css={css`width: 100%;`}>
-          <input type="text" placeholder="제목" css={inputTagCSS} value={title} onChange={titleHandler} required />
+          <input type="text" placeholder="제목" css={inputTagCSS} value={title} onChange={(e) => setTitle(e.target.value)} required />
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
           <DivideLine />
           <Button theme="green">글 작성</Button>
         </form>

--- a/src/pages/community/[character_id]/edit.tsx
+++ b/src/pages/community/[character_id]/edit.tsx
@@ -6,23 +6,32 @@ import DivideLine from '@/components/common/divideLine/DivideLine';
 import Button from '@/components/common/button/Button';
 import { createPost } from '@/utils/api/boards';
 import { useRouter } from 'next/router';
+import Toast from '@/components/common/toast/Toast';
 
 const Post = () => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [toastMessage, setToastMessage] = useState('');
   const router = useRouter();
   const { character_id: characterId } = router.query;
+
+  const handleToastClose = () => {
+    setToastMessage('');
+  };
+  const messageHandler = (message: string) => {
+    setToastMessage(message);
+  };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (characterId && typeof characterId === 'string') {
       if (title === '' || title.length > 30) {
-        alert('제목을 30자 이내로 작성해주세요! :)');
+        messageHandler('제목을 30자 이내로 작성해주세요! :)');
         return;
       }
 
       if (content === '' || content.length > 3000) {
-        alert('내용은 3000자 이내로 작성해주세요! :)');
+        messageHandler('내용은 3000자 이내로 작성해주세요! :)');
         return;
       }
 
@@ -34,7 +43,7 @@ const Post = () => {
         });
         return;
       }
-      alert('게시글 작성에 실패했습니다 :(');
+      messageHandler('게시글 작성에 실패했습니다 :(');
     }
     router.push({
       pathname: '/community',
@@ -60,6 +69,11 @@ const Post = () => {
           </div>
         </form>
       </section>
+      {
+        toastMessage
+          ? <Toast message={toastMessage} handleClose={handleToastClose} />
+          : null
+      }
     </>
   );
 };

--- a/src/pages/community/[character_id]/edit.tsx
+++ b/src/pages/community/[character_id]/edit.tsx
@@ -1,0 +1,60 @@
+import { css } from '@emotion/react';
+import SEO from '@/components/common/head/SEO';
+import { ChangeEvent, FormEvent, useState } from 'react';
+import PostHeader from '@/components/community/PostHeader';
+import DivideLine from '@/components/common/divideLine/DivideLine';
+import Button from '@/components/common/button/Button';
+import { useRouter } from 'next/router';
+
+const Post = () => {
+  const [title, setTitle] = useState('');
+  // const [content, setContent] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // TODO: 게시글 유효성 검사를 해야함
+
+    // 게시글 작성 성공!
+    router.push({
+      pathname: '/community',
+    });
+  };
+
+  const titleHandler = (e: ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+
+  return (
+    <>
+      <SEO title="Community - Post Editor" />
+      <PostHeader />
+      <section css={pageCSS}>
+        <form onSubmit={handleSubmit} css={css`width: 100%;`}>
+          <input type="text" placeholder="제목" css={inputTagCSS} value={title} onChange={titleHandler} required />
+          <DivideLine />
+          <Button theme="green">글 작성</Button>
+        </form>
+      </section>
+    </>
+  );
+};
+export default Post;
+
+const pageCSS = css`
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 3rem;
+`;
+
+const inputTagCSS = css`
+  width: 100%;
+  padding: 0.25rem 1rem;
+  font-size: 1rem;
+  outline: none;
+  background: none;
+  border: none;
+`;

--- a/src/utils/api/boards.ts
+++ b/src/utils/api/boards.ts
@@ -9,3 +9,8 @@ export const findPostById = async (characterId: string, postId: string) => {
   const result = await webServerInstance.get(`boards/${characterId}/${postId}`);
   return result.data;
 };
+
+export const createPost = async (characterId: string, title: string, content: string) => {
+  const result = await webServerInstance.post(`boards/${characterId}`, { title, content });
+  return result;
+};


### PR DESCRIPTION
## Feature: 게시글 작성 페이지 구현

### PR을 한 이유 🎯

- 게시글을 작성하는 페이지 구현을 위해서 Feature들을 만들었습니다.

### 이슈 번호 📎

- closed #95 

### 변경사항 🛠

- 게시글 작성에 필요한 UI 제작
- 기존에 만들어진 버튼 컴포넌트를 활용하여 재사용성을 높힘
- API 인스턴스에 함수를 추가해서 게시글 작성 POST 요청할 수 있도록 함
- 게시판에서 등록된 게시글이 보이는지 확인함

### 특이사항 📌

- 제목 30자, 텍스트 3000자를 넘으면 게시글을 쓸 수 없도록 조치했음. 백엔드와 몇자까지 넣을지 확인하면 좋을 것같음
- 게시글의 순서가 최신이 먼저 나와야할 것 같음

### 테스트 결과 📝

<img width="370" alt="image" src="https://github.com/TeamATM/toonchat-client/assets/90738604/03c74677-0e7a-4426-aeb6-035eb59fc26e">
<img width="397" alt="image" src="https://github.com/TeamATM/toonchat-client/assets/90738604/ead8d354-a44e-49fa-9cfc-6502c2384e82">
