### PR TITLE
Feature: 게시글 작성 버튼 생성

### DIFF
--- a/src/components/community/PostHeader.tsx
+++ b/src/components/community/PostHeader.tsx
@@ -28,7 +28,7 @@ const PostHeader = () => {
           characterInfo
             ? (
               <CharacterInfo
-                profileImageUrl="/leeyj.png"
+                profileImageUrl={characterInfo.profileImageUrl}
                 characterName={`${characterInfo.characterName} 게시판`}
                 hashTag={characterInfo.hashTag}
                 link={`/community/${characterInfo.characterId}`}

--- a/src/components/community/WriteButton.tsx
+++ b/src/components/community/WriteButton.tsx
@@ -1,0 +1,49 @@
+import color from '@/styles/color';
+import PostWriteIcon from '@/components/icons/PostWriteIcon';
+import { css } from '@emotion/react';
+
+const WriteButton = () => {
+  const buttonHandler = () => {
+    console.log(1);
+  };
+
+  return (
+    <button onClick={buttonHandler} css={buttonCSS} type="button">
+      <PostWriteIcon color={color.black} />
+      <span css={textCSS}>글쓰기</span>
+    </button>
+  );
+};
+
+export default WriteButton;
+
+const buttonCSS = css`
+  position: fixed;
+  top: 80%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 10rem;
+  z-index: 5;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+
+  padding: 0.5rem;
+  border: none;
+  border-radius: 1rem;
+
+  background-color: ${color.offWhite};
+  color: ${color.black};
+
+  &:active, &:hover {
+    background-color: ${color.lightGray};
+  }
+
+`;
+
+const textCSS = css`
+  font-size: 1rem;
+`;

--- a/src/components/community/WriteButton.tsx
+++ b/src/components/community/WriteButton.tsx
@@ -1,10 +1,16 @@
 import color from '@/styles/color';
 import PostWriteIcon from '@/components/icons/PostWriteIcon';
 import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
 
 const WriteButton = () => {
+  const router = useRouter();
+  const { character_id: characterId } = router.query;
+
   const buttonHandler = () => {
-    console.log(1);
+    if (characterId && typeof characterId === 'string') {
+      router.push(`/community/${characterId}/edit`);
+    }
   };
 
   return (

--- a/src/components/icons/PostWriteIcon.tsx
+++ b/src/components/icons/PostWriteIcon.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+import { IconProps } from '@/types/icon';
+
+const PostWriteIcon: FC<IconProps> = ({ color }) => (
+  <svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M16 8H14V5H11V3H14V0H16V3H19V5H16V8Z" fill={color} />
+    <path d="M18 10H16V13H5.334C4.90107 12.9988 4.47964 13.1393 4.134 13.4L2 15V3H9V1H2C0.89543 1 0 1.89543 0 3V19L4.8 15.4C5.14582 15.1396 5.56713 14.9992 6 15H16C17.1046 15 18 14.1046 18 13V10Z" fill={color} />
+  </svg>
+);
+
+export default PostWriteIcon;

--- a/src/pages/community/[character_id]/index.tsx
+++ b/src/pages/community/[character_id]/index.tsx
@@ -3,12 +3,14 @@ import BottomNavBar from '@/components/common/bottomNavBar/BottomNavBar';
 import SEO from '@/components/common/head/SEO';
 import PostList from '@/components/community/PostList';
 import CommunityHeader from '@/components/community/CommunityHeader';
+import WriteButton from '@/components/community/WriteButton';
 
 const Board = () => (
   <>
     <SEO title="Community - Board" />
     <section css={pageCSS}>
       <CommunityHeader />
+      <WriteButton />
       <PostList />
     </section>
     <BottomNavBar pageName="Community" />


### PR DESCRIPTION
## Feature: 게시글 작성 버튼 생성

### PR을 한 이유 🎯

- 게시판에서 게시글 작성 버튼을 누르면 게시글 작성 페이지로 넘어가도록 하는 기능이 필요합니다.

### 이슈 번호 📎

- closed #109

### 변경사항 🛠

- 게시판에 게시글 작성 버튼을 fixed로 화면에 고정했습니다.
- 버튼을 누르면 게시글 작성 페이지로 라우팅됩니다.

### 특이사항 📌

- 캐릭터 ID를 url에서 뽑아와서 API나 이곳저곳에 사용할 때 공통적으로 사용하는 로직이 있습니다.
      `if (characterId && typeof characterId === 'string')` 이 코드를 모든 구간에 사용하는 것이 올바르지 않은 것 같아서 리팩토링이 필요해보입니다.

### 테스트 결과 📝

<img width="382" alt="image" src="https://github.com/TeamATM/toonchat-client/assets/90738604/0bd0534f-cf4e-4312-8f55-9908d207d99f">