### PR TITLE
Feature: PWA 내에서 이미지 캐싱

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -37,7 +37,19 @@ const config = {
 
 const nextConfig = withPWA({
   dest: 'public',
-  runtimeCaching: [],
+  runtimeCaching: [
+    {
+      urlPattern: /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
+      handler: 'StaleWhileRevalidate',
+      options: {
+        cacheName: 'static-image-assets',
+        expiration: {
+          maxEntries: 64,
+          maxAgeSeconds: 24 * 60 * 60, // 24 hours
+        },
+      },
+    },
+  ],
   disableDevLogs: true,
 })(config);
 


### PR DESCRIPTION
## Feature: PWA 내에서 이미지 캐싱

### PR을 한 이유 🎯

- 이미지 파일을 계속 보내달라고 요청하는 것을 PWA를 통해 브라우저에서 캐싱이 가능한지 확인하기 위함